### PR TITLE
Update resque-rollbar.gemspec

### DIFF
--- a/resque-rollbar.gemspec
+++ b/resque-rollbar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'resque'
-  gem.add_dependency 'rollbar', '~> 0.9.9'
+  gem.add_dependency 'rollbar', '~> 0.9'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'json'


### PR DESCRIPTION
Any idea on when this gem will be updated?

The version number is too strict, this gem requires a very specific version of rollbar.

None of the recent breaking changes appear to affect this gem
