### PR TITLE
Bump the rollbar dependency to 0.12

### DIFF
--- a/resque-rollbar.gemspec
+++ b/resque-rollbar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'resque'
-  gem.add_dependency 'rollbar', '~> 0.8'
+  gem.add_dependency 'rollbar', '~> 0.12'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'json'


### PR DESCRIPTION
Just updating the Rollbar dependency to 0.12 because they are on version 0.12.8 now and this is locked at 0.8.

Maybe in the future can just make this above a certain rollbar version?
