### PR TITLE
set use_async = false

### DIFF
--- a/lib/resque/rollbar.rb
+++ b/lib/resque/rollbar.rb
@@ -1,1 +1,8 @@
 require 'resque/failure/rollbar'
+
+Resque.before_first_fork do
+  # Force synchronous reporting
+  ::Rollbar.configure do |config|
+    config.use_async = false
+  end
+end

--- a/spec/resque/failure/rollbar_spec.rb
+++ b/spec/resque/failure/rollbar_spec.rb
@@ -10,5 +10,7 @@ describe Resque::Failure::Rollbar do
     Rollbar.should_receive(:report_exception).with(exception, payload)
     backend = Resque::Failure::Rollbar.new(exception, worker, queue, payload)
     backend.save
+
+    expect(Rollbar.configuration.use_async).to be false
   end
 end


### PR DESCRIPTION
Hey @dimko, this is the only difference between this lib and https://github.com/CrowdFlower/resque-rollbar.

If this is merged, then we can have rollbar redirect to your lib and gem!
