### PR TITLE
Prepare Resque::Failure::Rollbar for 1.4.0.

### DIFF
--- a/lib/resque/failure/rollbar.rb
+++ b/lib/resque/failure/rollbar.rb
@@ -5,7 +5,21 @@ module Resque
   module Failure
     class Rollbar < Base
       def save
-        ::Rollbar.error(exception, payload)
+        if use_exception_level_filters?
+          payload_with_options = payload.merge(:use_exception_level_filters => true)
+        else
+          payload_with_options = payload
+        end
+
+        ::Rollbar.error(exception, payload_with_options)
+      end
+
+      def use_exception_level_filters?
+        rollbar_version.split('.')[1].to_i > 3
+      end
+
+      def rollbar_version
+        ::Rollbar::VERSION
       end
     end
   end

--- a/spec/resque/failure/rollbar_spec.rb
+++ b/spec/resque/failure/rollbar_spec.rb
@@ -1,14 +1,29 @@
 require 'spec_helper'
 
 describe Resque::Failure::Rollbar do
-  it 'should be notified of an error' do
-    exception = StandardError.new('BOOM')
-    worker    = Resque::Worker.new(:test)
-    queue     = 'test'
-    payload   = { 'class' => Object, 'args' => 89 }
+  let(:exception) { StandardError.new('BOOM') }
+  let(:worker) { Resque::Worker.new(:test) }
+  let(:queue) { 'test' }
+  let(:payload) { { 'class' => Object, 'args' => 89 } }
+  let(:backend) do
+    Resque::Failure::Rollbar.new(exception, worker, queue, payload)
+  end
 
+  it 'should be notified of an error' do
     expect(Rollbar.notifier).to receive(:log).with('error', exception, payload)
-    backend = Resque::Failure::Rollbar.new(exception, worker, queue, payload)
     backend.save
+  end
+
+  context 'with Rollbar version > 1.3' do
+    let(:payload_with_options) { payload.merge(:use_exception_level_filters => true) }
+
+    before do
+      allow(backend).to receive(:rollbar_version).and_return('1.4.0')
+    end
+
+    it 'sends the :use_exception_level_filters option' do
+      expect(Rollbar.notifier).to receive(:error).with(exception, payload_with_options)
+      backend.save
+    end
   end
 end


### PR DESCRIPTION
We have change some behaviour of public interface in Rollbar gem, now middlewares should pass :use_exception_level_filters => true option.

This change has been decided since the users expect to have an `error` level when they use manually `Rollbar.error`, but middlewares and other exception handlers should use the exception levels defined with `Rollbar.configure`.